### PR TITLE
Force const declarations to be on their own line for better readability

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,10 +102,11 @@ module.exports = {
     ],
     "eol-last": "error",
     "vars-on-top": "error",
-    "one-var": [
-      "error",
-      "always"
-    ],
+    "one-var": ["error", {
+      "var": "always", // Exactly one var declaration per function
+      "let": "always", // Exactly one let declaration per block
+      "const": "never" // Exactly one declarator per const declaration per block
+    }],
     "space-return-throw-case": "off",
     "space-infix-ops": "error",
     "space-before-blocks": [


### PR DESCRIPTION
Forcing `const` to be chained like `var` and `let` leads to awkward situations with longer strings and objects (which are likely to be `const`s). And since you can't declare-then-define-later like you can with `var`/`let`, we should turn this off for `const`.