### PR TITLE
Adding the MemberExpression option

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,8 @@ module.exports = {
       "error",
       2,
       {
-        "SwitchCase": 1
+        "SwitchCase": 1,
+        "MemberExpression": 1
       }
     ],
     "new-cap": "error",


### PR DESCRIPTION
Enforces indentation on multiline expressions (chaining, a la .then() etc)

http://eslint.org/docs/rules/indent#memberexpression