### PR TITLE
removes prefer-arrow-callback rule since mocha likes plain ol' functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ module.exports = {
     "prefer-const": "warn",
     "no-var": "warn",
     "prefer-template": "warn",
-    "prefer-arrow-callback": ["error", { "allowNamedFunctions": true }],
     "arrow-parens": ["error", "always"],
     "arrow-spacing": "error",
     "arrow-body-style": ["error", "as-needed"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sparkpost",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "ESLint configuration for SparkPost",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Since we lint our tests, `prefer-arrow-callback` will result in diffs like:

```
-describe('User Controller Tests', function() {
+describe('User Controller Tests', () => {
```

This is bad for mocha which relies on special behavior for `this`. I'm rolling this back.

I made this a patch (bug) fix... could be a minor ¯\_(ツ)_/¯