### PR TITLE
FAD-5478 Warn on anonymous functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ module.exports = {
       "error",
       "self"
     ],
+    "func-names": "warn",
     "curly": [
       "error",
       "all"

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
       "error",
       "self"
     ],
-    "func-names": "warn",
+    "func-names": ["error", "as-needed"],
     "curly": [
       "error",
       "all"

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "eslintconfig"
   ],
   "author": "SparkPost",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "eslint": "^4.13.0"
+  }
 }


### PR DESCRIPTION
It was observed during the RND for APM that we have several cases where we use anonymous functions in the execution cycle of our API endpoints. Fixing these will allow us to see further into the stack, and pinpoint any additional problems further down into our model methods.