### PR TITLE
added spread rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = {
   },
   "parserOptions": {
     "ecmaVersion": 8
-  }
+  },
   "extends": "eslint:recommended",
   "rules": {
     "prefer-const": "error",

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ module.exports = {
   "extends": "eslint:recommended",
   "rules": {
     "prefer-const": "error",
+    "prefer-rest-params": "error",
+    "prefer-spread": "error",
     "no-var": "error",
     "prefer-template": "error",
     "max-params": ["error", 3],
@@ -44,7 +46,11 @@ module.exports = {
       "single"
     ],
     "no-undef": "error",
-    "no-unused-vars": "error",
+    "no-unused-vars": ["error",
+      {
+        "ignoreRestSiblings": true
+      }
+    ],
     "semi": [
       "error",
       "always"

--- a/index.js
+++ b/index.js
@@ -2,6 +2,9 @@ module.exports = {
   "env": {
     "es6": true
   },
+  "parserOptions": {
+    "ecmaVersion": 8
+  }
   "extends": "eslint:recommended",
   "rules": {
     "prefer-const": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "eslint-config-sparkpost",
+  "version": "1.4.1",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION

**Scenario:**
```
const { dumpKey, ...data } = vars;
console.log(data);
```

That was failing for unused var dumpKey.  While looking up rules I added some other rest operator rules to prefer them over the "old" way