### PR TITLE
Hotfix/require jsdoc

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,14 +72,37 @@ module.exports = {
     'template-curly-spacing': ['error', 'never'],
     'vars-on-top': 'error',
     'wrap-iife': ['error', 'any'],
-    yoda: ['error', 'never']
+    yoda: ['error', 'never'],
+    'require-jsdoc': ['error', {
+      'require': {
+          'FunctionDeclaration': true,
+          'MethodDefinition': true,
+          'ClassDeclaration': true,
+          'ArrowFunctionExpression': true,
+          'FunctionExpression': true
+      }
+    }],
+    'valid-jsdoc': ['error', {
+      'prefer': {
+        'return': 'returns',
+        'arg': 'param',
+        'argument': 'param'
+      },
+      'requireReturnType': true,
+      'matchDescription': '.+',
+      'requireParamDescription': true,
+      'requireReturnDescription': false
+    }]
   },
   overrides: [
     {
       files: ['*.spec.js'],
       rules: {
         'func-names': 'off',
-        'prefer-arrow-callback': 'off'
+        'prefer-arrow-callback': 'off',
+        'max-params': 'off',
+        'require-jsdoc': 'off',
+        'valid-jsdoc': 'off'
       }
     }
   ]

--- a/index.js
+++ b/index.js
@@ -73,26 +73,32 @@ module.exports = {
     'vars-on-top': 'error',
     'wrap-iife': ['error', 'any'],
     yoda: ['error', 'never'],
-    'require-jsdoc': ['error', {
-      'require': {
-          'FunctionDeclaration': true,
-          'MethodDefinition': true,
-          'ClassDeclaration': true,
-          'ArrowFunctionExpression': true,
-          'FunctionExpression': true
+    'require-jsdoc': [
+      'error',
+      {
+        require: {
+          FunctionDeclaration: true,
+          MethodDefinition: true,
+          ClassDeclaration: true,
+          ArrowFunctionExpression: true,
+          FunctionExpression: true
+        }
       }
-    }],
-    'valid-jsdoc': ['error', {
-      'prefer': {
-        'return': 'returns',
-        'arg': 'param',
-        'argument': 'param'
-      },
-      'requireReturnType': true,
-      'matchDescription': '.+',
-      'requireParamDescription': true,
-      'requireReturnDescription': false
-    }]
+    ],
+    'valid-jsdoc': [
+      'error',
+      {
+        prefer: {
+          return: 'returns',
+          arg: 'param',
+          argument: 'param'
+        },
+        requireReturnType: true,
+        matchDescription: '.+',
+        requireParamDescription: true,
+        requireReturnDescription: false
+      }
+    ]
   },
   overrides: [
     {

--- a/ui.js
+++ b/ui.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 module.exports = {
   env: {
@@ -6,5 +6,5 @@ module.exports = {
     phantomjs: true,
     protractor: true
   },
-  extends: 'sparkpost/index'
+  extends: "sparkpost/index"
 };

--- a/ui.js
+++ b/ui.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 module.exports = {
   env: {
@@ -6,5 +6,5 @@ module.exports = {
     phantomjs: true,
     protractor: true
   },
-  extends: "sparkpost/index"
+  extends: 'sparkpost/index'
 };


### PR DESCRIPTION
We try to make sure functions are doc'd and with accurate syntax but this is def a mixed bag.  I think it is good for us to have these rules in place. It definitely helps with new hires or people new to the code.  Since most repos have switch to only linting on staged commits this will be a work in progress.

I also am excluding some of our linting rules in tests as we got burned on max params and func names before