### PR TITLE
Tweak comma settings to play nicer with prettier

### DIFF
--- a/api.js
+++ b/api.js
@@ -3,7 +3,7 @@
 module.exports = {
   env: {
     node: true,
-    mocha: true
+    mocha: true,
   },
-  extends: 'sparkpost/index'
+  extends: 'sparkpost/index',
 };

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = {
     'eol-last': 'error',
     eqeqeq: 'error',
     'func-names': ['error', 'as-needed'],
-    indent: ['error', 2, { SwitchCase: 1 }],
+    indent: ['error', 2, { SwitchCase: 1, VariableDeclarator: 2 }],
     'key-spacing': ['error', { beforeColon: false, afterColon: true }],
     'keyword-spacing': ['error', { before: true, after: true }],
     'linebreak-style': ['error', 'unix'],

--- a/index.js
+++ b/index.js
@@ -2,10 +2,10 @@
 
 module.exports = {
   env: {
-    es6: true
+    es6: true,
   },
   parserOptions: {
-    ecmaVersion: 2018
+    ecmaVersion: 2018,
   },
   extends: 'eslint:recommended',
   rules: {
@@ -14,12 +14,8 @@ module.exports = {
     'arrow-spacing': 'error',
     'brace-style': ['error', '1tbs', { allowSingleLine: true }],
     camelcase: 'off',
-    'comma-dangle': ['error', 'never'],
-    'comma-style': [
-      'error',
-      'first',
-      { exceptions: { ArrayExpression: true, ObjectExpression: true } }
-    ],
+    'comma-dangle': ['error', 'always-multiline'],
+    'comma-style': ['error', 'last'],
     complexity: ['error', 5],
     'consistent-this': ['error', 'self'],
     curly: ['error', 'all'],
@@ -52,8 +48,8 @@ module.exports = {
       {
         var: 'always', // Exactly one var declaration per function
         let: 'always', // Exactly one let declaration per block
-        const: 'never' // Exactly one declarator per const declaration per block
-      }
+        const: 'never', // Exactly one declarator per const declaration per block
+      },
     ],
     'operator-linebreak': ['error', 'before', { overrides: { '=': 'none' } }],
     'prefer-arrow-callback': ['error', { allowNamedFunctions: true }],
@@ -72,15 +68,15 @@ module.exports = {
     'template-curly-spacing': ['error', 'never'],
     'vars-on-top': 'error',
     'wrap-iife': ['error', 'any'],
-    yoda: ['error', 'never']
+    yoda: ['error', 'never'],
   },
   overrides: [
     {
       files: ['*.spec.js'],
       rules: {
         'func-names': 'off',
-        'prefer-arrow-callback': 'off'
-      }
-    }
-  ]
+        'prefer-arrow-callback': 'off',
+      },
+    },
+  ],
 };

--- a/ui.js
+++ b/ui.js
@@ -4,7 +4,7 @@ module.exports = {
   env: {
     browser: true,
     phantomjs: true,
-    protractor: true
+    protractor: true,
   },
-  extends: 'sparkpost/index'
+  extends: 'sparkpost/index',
 };


### PR DESCRIPTION
change from:
```js
let something
  ,anotherThing
  ,and somethingElse;
```
to
```js
let something,
    anotherThing,
    somethingElse;
```

As for trailing commas, from https://github.com/airbnb/javascript#commas--dangling
> Why? This leads to cleaner git diffs...